### PR TITLE
Standardize CI (tier: important)

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,53 +1,17 @@
-# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
-# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+name: R-CMD-check
 on:
   push:
     branches: [main, master]
   pull_request:
     branches: [main, master]
-
-name: R-CMD-check
-
-permissions: read-all
-
+permissions:
+  contents: read
 jobs:
   R-CMD-check:
-    runs-on: ${{ matrix.config.os }}
-
-    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
-
-    strategy:
-      fail-fast: false
-      matrix:
-        config:
-          - {os: macos-latest,   r: 'release'}
-          - {os: windows-latest, r: 'release'}
-          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
-          - {os: ubuntu-latest,   r: 'release'}
-          - {os: ubuntu-latest,   r: 'oldrel-1'}
-
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      R_KEEP_PKG_SOURCE: yes
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: r-lib/actions/setup-pandoc@v2
-
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          r-version: ${{ matrix.config.r }}
-          http-user-agent: ${{ matrix.config.http-user-agent }}
-          use-public-rspm: true
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: any::rcmdcheck
-          needs: check
-
-      - uses: r-lib/actions/check-r-package@v2
-        with:
-          upload-snapshots: true
-          build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'
-          
+    uses: poissonconsulting/.github/.github/workflows/R-CMD-check.yaml@v1
+    with:
+      tier: important
+      jags: false
+      tex: false
+      private: false
+    secrets: inherit

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,5 +1,4 @@
-# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
-# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+name: pkgdown
 on:
   push:
     branches: [main, master]
@@ -8,43 +7,11 @@ on:
   release:
     types: [published]
   workflow_dispatch:
-
-name: pkgdown.yaml
-
-permissions: read-all
-
+permissions:
+  contents: write
 jobs:
   pkgdown:
-    runs-on: ubuntu-latest
-    # Only restrict concurrency for non-PR jobs
-    concurrency:
-      group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: r-lib/actions/setup-pandoc@v2
-
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: any::pkgdown, local::.
-          needs: website
-
-      - name: Build site
-        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
-        shell: Rscript {0}
-
-      - name: Deploy to GitHub pages 🚀
-        if: github.event_name != 'pull_request'
-        uses: JamesIves/github-pages-deploy-action@v4.5.0
-        with:
-          clean: false
-          branch: gh-pages
-          folder: docs
+    uses: poissonconsulting/.github/.github/workflows/pkgdown.yaml@v1
+    with:
+      private: false
+    secrets: inherit

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,63 +1,15 @@
-# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
-# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+name: test-coverage
 on:
   push:
     branches: [main, master]
   pull_request:
     branches: [main, master]
-
-name: test-coverage
-
-permissions: read-all
-
+permissions:
+  contents: read
 jobs:
   test-coverage:
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: any::covr, any::xml2
-          needs: coverage
-
-      - name: Test coverage
-        run: |
-          cov <- covr::package_coverage(
-            quiet = FALSE,
-            clean = FALSE,
-            install_path = file.path(normalizePath(Sys.getenv("RUNNER_TEMP"), winslash = "/"), "package")
-          )
-          print(cov)
-          covr::to_cobertura(cov)
-        shell: Rscript {0}
-
-      - uses: codecov/codecov-action@v4
-        with:
-          # Fail if error if not on PR, or if on PR and token is given
-          fail_ci_if_error: ${{ github.event_name != 'pull_request' || secrets.CODECOV_TOKEN }}
-          file: ./cobertura.xml
-          plugin: noop
-          disable_search: true
-          token: ${{ secrets.CODECOV_TOKEN }}
-
-      - name: Show testthat output
-        if: always()
-        run: |
-          ## --------------------------------------------------------------------
-          find '${{ runner.temp }}/package' -name 'testthat.Rout*' -exec cat '{}' \; || true
-        shell: bash
-
-      - name: Upload test results
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-test-failures
-          path: ${{ runner.temp }}/package
+    uses: poissonconsulting/.github/.github/workflows/test-coverage.yaml@v1
+    with:
+      tex: false
+      private: false
+    secrets: inherit

--- a/R/test-helpers.R
+++ b/R/test-helpers.R
@@ -114,7 +114,7 @@ save_csv <- function(x) {
 }
 
 expect_snapshot_data <- function(x, name, digits = 6) {
-  fun <- function(x) signif(x, digits = digits)
+  fun <- function(x) if (is.numeric(x)) signif(x, digits = digits) else x
   lapply_fun <- function(x) I(lapply(x, fun))
   x <- dplyr::mutate(x, dplyr::across(dplyr::where(is.numeric), fun))
   x <- dplyr::mutate(x, dplyr::across(dplyr::where(is.list), lapply_fun))

--- a/R/wqb-method-ssd.R
+++ b/R/wqb-method-ssd.R
@@ -94,7 +94,7 @@ wqb_ssd_fit <- function(data, dists = ssdtools::ssd_dists_bcanz()) {
 #' hc5 <- wqb_ssd_hc5(fit)
 #' }
 wqb_ssd_hc5 <- function(fit, nboot = 1000) {
-  tbl <- ssdtools::ssd_hc_bcanz(fit, nboot = nboot) |>
+  tbl <- ssdtools::ssd_hc_bcanz(fit, nboot = nboot, ci = TRUE) |>
     dplyr::filter(.data$proportion == 0.05)
   tbl
 }

--- a/tests/testthat/_snaps/wqb-generate-ctv/ssdtool_bcanz.csv
+++ b/tests/testthat/_snaps/wqb-generate-ctv/ssdtool_bcanz.csv
@@ -1,5 +1,5 @@
-dist,proportion,est,se,lcl,ucl,wt,method,nboot,pboot,samples
-average,0.01,0.533008,0.23598,0.385599,1.10449,1,parametric,10,1,numeric(0)
-average,0.05,0.869329,0.222381,0.675533,1.35957,1,parametric,10,1,numeric(0)
-average,0.1,1.06702,0.223582,0.855102,1.54019,1,parametric,10,1,numeric(0)
-average,0.2,1.34743,0.238311,1.11621,1.81078,1,parametric,10,1,numeric(0)
+dist,proportion,est,se,lcl,ucl,wt,level,est_method,ci_method,boot_method,nboot,pboot,dists,samples
+average,0.01,0.533008,0.23598,0.385599,1.10449,1,0.95,multi,weighted_samples,parametric,10,1,"c(""gamma"", ""lgumbel"", ""llogis"", ""lnorm"", ""lnorm_lnorm"", ""weibull"")",numeric(0)
+average,0.05,0.869329,0.222381,0.675533,1.35957,1,0.95,multi,weighted_samples,parametric,10,1,"c(""gamma"", ""lgumbel"", ""llogis"", ""lnorm"", ""lnorm_lnorm"", ""weibull"")",numeric(0)
+average,0.1,1.06702,0.223582,0.855102,1.54019,1,0.95,multi,weighted_samples,parametric,10,1,"c(""gamma"", ""lgumbel"", ""llogis"", ""lnorm"", ""lnorm_lnorm"", ""weibull"")",numeric(0)
+average,0.2,1.34743,0.238311,1.11621,1.81078,1,0.95,multi,weighted_samples,parametric,10,1,"c(""gamma"", ""lgumbel"", ""llogis"", ""lnorm"", ""lnorm_lnorm"", ""weibull"")",numeric(0)

--- a/tests/testthat/_snaps/wqb-generate-ctv/ssdtool_hc.csv
+++ b/tests/testthat/_snaps/wqb-generate-ctv/ssdtool_hc.csv
@@ -1,6 +1,6 @@
-dist,proportion,est,se,lcl,ucl,wt,method,nboot,pboot,samples
-gamma,0.05,0.950515,0.336198,0.622655,1.91211,0.236757,parametric,100,1,numeric(0)
-lgumbel,0.05,1.03321,0.239381,0.706971,1.75036,0.135692,parametric,100,1,numeric(0)
-llogis,0.05,0.972097,0.34172,0.478799,1.85409,0.175878,parametric,100,1,numeric(0)
-lnorm,0.05,1.00267,0.296023,0.680286,1.88285,0.218508,parametric,100,1,numeric(0)
-weibull,0.05,0.834054,0.403442,0.353718,1.74827,0.233166,parametric,100,1,numeric(0)
+dist,proportion,est,se,lcl,ucl,wt,level,est_method,ci_method,boot_method,nboot,pboot,dists,samples
+gamma,0.05,0.950515,0.336198,0.622655,1.91211,0.236757,0.95,cdf,percentile,parametric,100,1,gamma,numeric(0)
+lgumbel,0.05,1.03321,0.239381,0.706971,1.75036,0.135692,0.95,cdf,percentile,parametric,100,1,lgumbel,numeric(0)
+llogis,0.05,0.972097,0.34172,0.478799,1.85409,0.175878,0.95,cdf,percentile,parametric,100,1,llogis,numeric(0)
+lnorm,0.05,1.00267,0.296023,0.680286,1.88285,0.218508,0.95,cdf,percentile,parametric,100,1,lnorm,numeric(0)
+weibull,0.05,0.834054,0.403442,0.353718,1.74827,0.233166,0.95,cdf,percentile,parametric,100,1,weibull,numeric(0)

--- a/tests/testthat/test-wqb-generate-ctv.R
+++ b/tests/testthat/test-wqb-generate-ctv.R
@@ -140,7 +140,7 @@ test_that("check ssdtools functions directly", {
     data = df,
     left = "sp_aggre_conc_mg.L"
   ) |>
-    ssdtools::ssd_hc_bcanz(nboot = 10)
+    ssdtools::ssd_hc_bcanz(nboot = 10, ci = TRUE)
 
   expect_snapshot_data(output, "ssdtool_bcanz")
 })
@@ -260,7 +260,7 @@ test_that("check ssdtools fit bcanz and bcanz hc functions", {
       data = df,
       left = "sp_aggre_conc_mg.L"
     ) |>
-      ssdtools::ssd_hc_bcanz(nboot = 100)
+      ssdtools::ssd_hc_bcanz(nboot = 100, ci = TRUE)
   )
 
   expect_equal(
@@ -270,12 +270,12 @@ test_that("check ssdtools fit bcanz and bcanz hc functions", {
 
   expect_equal(
     signif(output$se, 3),
-    c(0.315, 0.329, 0.342, 0.368)
+    c(0.315, 0.330, 0.343, 0.370)
   )
 
   expect_equal(
     signif(output$lcl, 3),
-    c(0.225, 0.473, 0.666, 0.983)
+    c(0.224, 0.471, 0.665, 0.983)
   )
 
   expect_equal(

--- a/tests/testthat/test-wqb-plot-det.R
+++ b/tests/testthat/test-wqb-plot-det.R
@@ -53,5 +53,5 @@ test_that("check type is a plot type", {
     "effect" = rep(NA, reps)
   )
   output <- wqb_plot_det(df)
-  expect_equal(class(output), c("gg", "ggplot"))
+  expect_s3_class(output, "ggplot")
 })

--- a/tests/testthat/test-wqb-plot-ssd.R
+++ b/tests/testthat/test-wqb-plot-ssd.R
@@ -31,5 +31,5 @@ test_that("type matches ggplot", {
   )
   fit <- wqb_ssd_fit(df, dists = c("lnorm", "llogis"))
   output <- wqb_plot_ssd(df, fit)
-  expect_equal(class(output), c("gg", "ggplot"))
+  expect_s3_class(output, "ggplot")
 })

--- a/tests/testthat/test-wqb-plot.R
+++ b/tests/testthat/test-wqb-plot.R
@@ -167,7 +167,7 @@ test_that("plot type is ggplot", {
     "version" = rep(NA, reps)
   )
   output <- wqb_plot(df)
-  expect_equal(class(output), c("gg", "ggplot"))
+  expect_s3_class(output, "ggplot")
 
   skip_on_ci()
   expect_snapshot_plot(output, "wqb_plot")
@@ -200,7 +200,7 @@ test_that("shape is present when there are 5 groups or less", {
     "version" = rep(NA, reps)
   )
   output <- wqb_plot(df)
-  expect_equal(class(output), c("gg", "ggplot"))
+  expect_s3_class(output, "ggplot")
 
   skip_on_ci()
   expect_snapshot_plot(output, "shape_5_groups")
@@ -233,7 +233,7 @@ test_that("shape is removed after 6 endpoint group are present set", {
     "version" = rep(NA, reps)
   )
   output <- wqb_plot(df)
-  expect_equal(class(output), c("gg", "ggplot"))
+  expect_s3_class(output, "ggplot")
 
   skip_on_ci()
   expect_snapshot_plot(output, "color_6_groups")

--- a/tests/testthat/test-wqb-summary-trophic-species.R
+++ b/tests/testthat/test-wqb-summary-trophic-species.R
@@ -58,7 +58,7 @@ test_that("error with character trophic groups", {
   )
   expect_error(
     wqb_summary_trophic_species(df),
-    regexp = "`data\\$trophic_group` must inherit from S3 class 'factor'"
+    regexp = "`data\\$trophic_group` must inherit from (S3 )?class 'factor'"
   )
 })
 


### PR DESCRIPTION
Standardizes CI onto the reusable workflows in `poissonconsulting/.github` (tier **important**, private=false, jags=false, tex=false). Callers: R-CMD-check, test-coverage, pkgdown; fledge callers unchanged.